### PR TITLE
fix: address DMARC and authentication problems

### DIFF
--- a/insert_expanded_headers
+++ b/insert_expanded_headers
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+
+## Script to insert Resent-From and Resent-To headers into emails received via stdin.
+##
+## The script scans for either an existing Resent-* header, or the end of the headers
+## as signified by a CRLF.  When one or the other is found, the Resent-From and
+## Resent-To headers inserted above the target line.
+## 
+## This results in our Resent-* headers being prepended to any existing Resent-*
+## headers as per section 3.6.6 of RFC 2822, or inserted at the end of the headers
+## if there are no previous Resent-* headers.
+
+## Import the sys module so we can read command line arguments
+import sys
+
+## Initialize the flag
+found = 0
+
+def expandDraft(draftname):
+    files = ["/a/postfix/draft-virtual","/a/postfix/group-virtual"]
+    result=""
+    for fn in files:
+    	try:	
+		with open(fn,'r') as f:
+    			for line in f:
+    				lineparts = line.split('@')
+    				if lineparts[0] == draftname:
+    					f.close()	
+					emails = line.replace(draftname,"")
+    					emails = emails.replace('@virtual.ietf.org','')
+    					return emails.strip()
+    	except:
+		f.close()
+		# A file error has occurred
+		# return an empty string, so the script continues to output the message 
+		return "" 	
+    return ""
+
+# get the expanded addresses
+try:
+	expandedAddresses = expandDraft(sys.argv[1])
+	draftname = sys.argv[1]
+except:
+	expandedAddresses = ""
+	draftname=""
+
+# if there are no expanded addresses, set the found flag to prevent further testing
+
+if expandedAddresses == "":
+	found = 1
+
+for line in sys.stdin:
+    try:
+	if found == 0:
+			if not line.strip(): #First blank line is the end of headers, insert
+                                        print """Resent-From: <alias-bounces@ietf.org>"""
+                                        print """Resent-To: %s""" % expandedAddresses
+                                        #print """X-IETF-Alias: %s""" % draftname
+					found=1
+					print line,
+			elif line[0:7] == "Resent-": #If there is a Resent-* header already, prepend ours
+                                        print """Resent-From: <alias-bounces@ietf.org>"""
+                                        print """Resent-To: %s""" % expandedAddresses
+                                        #print """X-IETF-Alias: %s""" % draftname
+					found=1
+					print line,
+			else:
+				print line,
+
+			
+	else:
+                                print line,
+    except:
+	continue

--- a/postconfirm.conf
+++ b/postconfirm.conf
@@ -75,6 +75,11 @@ smtp_host:	localhost
 # confirmation request template.
 admin_address:	"postmaster@shiraz.levkowetz.com"
 
+# The remail sender address is put on mail forwarded to role
+# addresses, so SPF will pass
+
+remail_sender: "mailforward@ietf.org"
+
 # If an incoming mail has a Precedence: header which matches the following
 # regex pattern, the mail will be dropped:
 

--- a/postconfirm/pctest.py
+++ b/postconfirm/pctest.py
@@ -57,6 +57,15 @@ class Testing:
         print msg,
         print "======"
 
+    def getlistinfo(self):
+        """
+        fake listinfo per mailman
+        """
+        listinfo = {
+            'ietf': { 'archive': True },
+            'iesg': { 'archive': False }
+            }
+        return listinfo
     
 conf = Config() # make an instance
 

--- a/postconfirm/pctest.py
+++ b/postconfirm/pctest.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python2
+#
+# test rig to run messages through postconfirm daemon
+#
+
+import service
+import sys
+import os
+import config
+
+# stub configuration that is also a dict
+# for conf.confirm.smtp.host etc.
+class ConfigMailRewriteSmtp: # conf.confirm.smtp and conf.dmarc.rewrite.smtp
+    host = 'localhost'
+    port = 10028
+
+class ConfigDmarcRequire: # conf.dmarc.require
+    header = dict()
+
+class ConfigMailRewrite: # conf.confirm and conf.dmarc.rewrite
+    smtp = ConfigMailRewriteSmtp()
+    quote_char = '='    # for DMARC rewrite addr
+    require = ConfigDmarcRequire()
+    
+class ConfigDmarcResolver: # conf.dmarc.resolver
+    lifetime = 10
+    timeout = 10
+
+class ConfigMail: # conf.dmarc
+    rewrite = ConfigMailRewrite()
+    domain = 'dmarc.ietf.org'
+    resolver= ConfigDmarcResolver()
+
+class Config(dict):
+    mail_cache_dir = 'cache'
+    key_file = 'hash.key'
+    whitelists = ['whitelist']
+    confirmlist = 'confirmlist'
+    whiteregex = ('whiteregex')
+    blacklists = ('blacklist')
+    blackregex = ('blackregex')
+    archive_url_pattern = "http://mailarchive.ietf.org/arch/msg/%(list)s/%(hash)s"
+    bulk_regex = "(junk|list|bulk|auto_reply)"
+    auto_submitted_regex = "^auto-"
+    mail_template = "confirm.email.template"
+    admin_address = "postmaster@test.ietf.org"
+    remail_sender = "mailforward@ietf.org"
+
+    # stubbed out in test, make placeholders for intermediate configs
+    dmarc = ConfigMail()
+    confirm = ConfigMailRewrite()
+
+# test routines to plug into the service
+class Testing:
+    def send_smtp(self, fromaddr, toaddrs, msg):
+        print "=== mail from %s to %s ===" % (fromaddr, toaddrs)
+        print msg,
+        print "======"
+
+    
+conf = Config() # make an instance
+
+# sys.argv = ['test', '-f' ,'johnl@taugh.com' ,'confirm', 'expand-blurch-chairs' ]
+os.environ["SENDER"] = 'johnl@taugh.com'
+
+service.testing = Testing() # do testing
+
+service.setup(conf, None)   # dummy files argument
+
+service.handler()

--- a/postconfirm/pctlist
+++ b/postconfirm/pctlist
@@ -3,18 +3,34 @@
 # run pctests
 set -v
 
-# forward to group
-./pctest.py -f johnl@taugh.com confirm blurch-chairs@ietf.org < testmsg1 > tmout1 && diff testmsg1 tmout1
+# forward to group, dkim should be ok
+if ./pctest.py -f johnl@taugh.com confirm blurch-chairs@ietf.org < testmsg1 > tmout1
+then
+ diff testmsg1 tmout1
+ dkimverify < tmout1
+fi
 
-# forward to list
-#./pctest.py -f johnl@taugh.com confirm blurch@ietf.org < testmsg4 > tmout4 && diff testmsg4 tmout4
+# no rewrite, DKIM should be OK
+if ./pctest.py -f johnl@taugh.com dmarc-rewrite blurch@ietf.org < testmsg2 > tmout2
+then
+  diff testmsg2 tmout2
+  sed -e '/^===/d' tmout2 | dkimverify
+fi
 
-# no rewrite
-#./pctest.py -f johnl@taugh.com dmarc-rewrite blurch@ietf.org < testmsg2 > tmout2 && diff testmsg2 tmout2
+# do rewrite, OK to rewrap
+if ./pctest.py -f johnl@examp1e.com dmarc-rewrite blurch@ietf.org < testmsg3 > tmout3
+then
+ diff testmsg3 tmout3
+fi
 
-# do rewrite
+# list with archive, don't rewrite
+if ./pctest.py -f johnl@examp1e.com confirm ietf@ietf.org < testmsg4> tmout4a
+then
+ diff testmsg4 tmout4a
+fi
 
-./pctest.py -f johnl@examp1e.com dmarc-rewrite blurch@ietf.org < testmsg3 > tmout3 && diff testmsg3 tmout3
-
-./pctest.py -f johnl@examp1e.com confirm blurch@ietf.org < testmsg3> tmout3a && diff testmsg3 tmout3a
-
+# lsit without archive
+if ./pctest.py -f johnl@examp1e.com confirm iesg@ietf.org < testmsg5> tmout5a
+then
+ diff testmsg5 tmout5a
+fi

--- a/postconfirm/pctlist
+++ b/postconfirm/pctlist
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# run pctests
+set -v
+
+# forward to group
+./pctest.py -f johnl@taugh.com confirm blurch-chairs@ietf.org < testmsg1 > tmout1 && diff testmsg1 tmout1
+
+# forward to list
+#./pctest.py -f johnl@taugh.com confirm blurch@ietf.org < testmsg4 > tmout4 && diff testmsg4 tmout4
+
+# no rewrite
+#./pctest.py -f johnl@taugh.com dmarc-rewrite blurch@ietf.org < testmsg2 > tmout2 && diff testmsg2 tmout2
+
+# do rewrite
+
+./pctest.py -f johnl@examp1e.com dmarc-rewrite blurch@ietf.org < testmsg3 > tmout3 && diff testmsg3 tmout3
+
+./pctest.py -f johnl@examp1e.com confirm blurch@ietf.org < testmsg3> tmout3a && diff testmsg3 tmout3a
+

--- a/postconfirm/testmsg
+++ b/postconfirm/testmsg
@@ -1,0 +1,16 @@
+Date: 30 Aug 2023 10:25:47 -0400
+Message-ID: <7ce4xxe6ac-93e0-a320-c52b-65e0fa9f8d96@taugh.com>
+From: "John R Levine" <johnl@taugh.com>
+To: uucp@computer.org
+Cc: blurch-chairs@ietf.org
+Subject: test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+
+Test message to send around
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly
+
+

--- a/postconfirm/testmsg1
+++ b/postconfirm/testmsg1
@@ -1,0 +1,25 @@
+Delivered-To: johnl@iecc.com
+Received: (qmail 11816 invoked from network); 25 Sep 2023 01:34:16 -0000
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=iecc.com; h=date:message-id:from:to:cc:subject:mime-version:content-type; s=2e22.6510e398.k2309; bh=3M2ylJytwFIDAlNHHod1ke5nYiiJcDlPjWICH/EW1AQ=; b=0VJvqf6NotHHTntChvKpUGEyQiEZQ76krwV/YkPxBNBhOo9wM9BqQ7344wh7ps5EbwZTSdhEYlXam1ruglOpd9G9GfqUJJNJ16qCeSOYcBSALt4fnkDmGqL8+eM1uMXV/JJknB5c3QAUWkLdMpfP5VUZ2Td5NXLr9g29BB0Lg2V+PfbE/QdetX4DHbDsDe6Jxx9dgevhHbzPUDGvlE3/FJpmCWaEkmriNNdQgzydqssQDAwcE4WUKZBXknguIqMFen0qbGYnmziWfTJHzDR5SHSLONmXDCkGeqFAUanwMa0kgb4+cvdB9AEn+l11/RsrumkDq23+lLidzhIcbe97Ow==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=taugh.com; h=date:message-id:from:to:cc:subject:mime-version:content-type; s=2e22.6510e398.k2309; bh=3M2ylJytwFIDAlNHHod1ke5nYiiJcDlPjWICH/EW1AQ=; b=VzaWcIR08eg65oic0lygG/R0uTsGKKWubXbdJjh/Dacp3PrVB5zdRoUvMRpRXqicpLJZykV5krmlJchzRMKzV4uHyfSLgbAysQSHXJ/ceF3ZLBDByjdiO0eIE51IOxRoSlrPaH0Gks1vRi0aG+1lFbW/fL1wdTMvlI4UsOmV70Vxya6qrcLLAIqD0UqtZrM80KbnaA01/xoYjLB8riJJJp/Xo9HP5NLPZcuA1tS06kSUi7usKnLNO7MDwa8blQTsj07Ds6+aKbD3ImsMaTwVqLDWAu4GMkYFARU4Mnjc4YXWX6HlcYbTKydAPBn2nlQN+SAroVUGq+NX1KJuJFej7w==
+Received: from ary.qy ([IPv6:2001:470:1f07:1126::78:696d:6170])
+  by imap.iecc.com ([IPv6:2001:470:1f07:1126::78:696d:6170])
+ with ESMTPS (TLS1.3 ECDHE-RSA CHACHA20-POLY1305 AEAD) via TCP6; 25 Sep 2023 01:34:16 -0000
+Received: by ary.qy (Postfix, from userid 501)
+	id E37E8233DC18; Sun, 24 Sep 2023 21:34:14 -0400 (EDT)
+Date: 24 Sep 2023 21:34:14 -0400
+Message-Id: <20230925013415.E37E8233DC18@ary.qy>
+From: "John R Levine" <johnl@taugh.com>
+To: uucp@computer.org
+Cc: blurch-chairs@ietf.org
+Subject: test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+
+Test message to send around
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly
+
+

--- a/postconfirm/testmsg2
+++ b/postconfirm/testmsg2
@@ -1,0 +1,24 @@
+Delivered-To: johnl@iecc.com
+Received: (qmail 15588 invoked from network); 25 Sep 2023 02:01:00 -0000
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=iecc.com; h=date:message-id:from:to:subject:mime-version:content-type; s=3ce0.6510e9dc.k2309; bh=r+LZb+IwiqYYj5K345Cm89G0V8jKxCNfeShtwqmQyaY=; b=duou8AkLIf1tW0kCiUMuuOrg43CAa1G1DCs9vSfFcKXdXeJ9CCDtzV8eNBszVg/aQBSF3uOYTD4RgORH4YI0T1KdNHIeJzGQCGJuXJyadIGYN6cbISZr3YI21CCXnBcA9DUf+10ZIzwXZMrCw572VAFFLUnKsmDiK1zlEcsAuCeMq+jVlKiqV8C5Eb/PPVhwHh+8TQlrpT57EPt28RzLDM6tJGxfegUfFqzxRHSTLr3lHV/HBLikOrgmtFSzBJ7l1/qT4OII2pmW33AZK8p/0REr2fZs6IgiXGsho/ESROooAX71oWV4bJxAVuSZvsvLMk5vy8pTif1Iys29ZnfZ/g==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=taugh.com; h=date:message-id:from:to:subject:mime-version:content-type; s=3ce0.6510e9dc.k2309; bh=r+LZb+IwiqYYj5K345Cm89G0V8jKxCNfeShtwqmQyaY=; b=Sz8Mz5zRyKXVVU+dY9YR58ZXfTBPTlbgkl3tOEpVNlR4Cg5MJ/Nm32MJeaiNhJem6bxvj0LPR7cGlWDkrWc9G6WXZyQHm1ymog2/9FL9eMPExpmfzkyxt3AG+Q6McRtddNoDhrTDjqunT6tOGnL8bRs+dNlfJv1oHC6ZDP8dF5sp1sMogKfnIeaTsISGRUe+pO8WhwMkyAhZgCb45bg9C5ULezwKrz0TlMAnXZ9h5VqhiiBWObWxbTJv5rOAlVAOohjhiYMH43iC/xdpY0oCUFjfcda0CIcxTe+gDCuToBi71uHXDfDXk8ZfUx/Je/fQubdh8324MuZtHxIsBGGp2Q==
+Received: from ary.qy ([IPv6:2001:470:1f07:1126::78:696d:6170])
+  by imap.iecc.com ([IPv6:2001:470:1f07:1126::78:696d:6170])
+ with ESMTPS (TLS1.3 ECDHE-RSA CHACHA20-POLY1305 AEAD) via TCP6; 25 Sep 2023 02:01:00 -0000
+Received: by ary.qy (Postfix, from userid 501)
+	id DE19F234E448; Sun, 24 Sep 2023 22:00:59 -0400 (EDT)
+Date: 24 Sep 2023 22:00:59 -0400
+Message-Id: <20230925020059.DE19F234E448@ary.qy>
+From: "John R Levine" <johnl@taugh.com>
+To: blurch@ietf.org
+Subject: mailing list test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+
+Test message to fake list
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly
+
+

--- a/postconfirm/testmsg3
+++ b/postconfirm/testmsg3
@@ -1,0 +1,24 @@
+Received: (qmail 10938 invoked from network); 25 Sep 2023 01:27:39 -0000
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=iecc.com; h=date:message-id:from:to:cc:subject:mime-version:content-type; s=2ab7.6510e20b.k2309; bh=FqjdeVcM/jo0rfB/SdG9xthyor2uhdf4RIKc6BwaLfY=; b=izQcw6QI5viTPtyI2zsvLmX73/4Ud1hA+MyJa8RK3Rem0M7F7c7rgayMCuSHpuPs9TZi8bjCj8eVqEbS0iyc6VJDidWq45c46fp3edET+SiZqwDpFlrmopleVaXkjBGGkq2JKvIdH5kD8AvAcD6LxFPILBGQ3BD0x4bbY4lfcravKAldoZOqkRpPHzDFMypO8w9kgIt1bv7TggU+A21mp57K716/Loms8eP/szv9dtdkRiOgvrCb7coeHUjekicMj2JQhKgJ5FA1ZXXLDv67KPm4jey7KNiOv2QO8x/qNgyLrOOilACCNZiHPS47OUUkBxtEfyDhXdHz8a9gY8ysSw==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=examp1e.com; h=date:message-id:from:to:cc:subject:mime-version:content-type; s=2ab7.6510e20b.k2309; bh=FqjdeVcM/jo0rfB/SdG9xthyor2uhdf4RIKc6BwaLfY=; b=qVXGhK69kBvMkn6v8EJiBp+IcuhMmClhUK38qGkL2eq9otXB7EqjDqgDgfVCXIamGQCgpElOS7ace7fn+wy2mFVQDLKmpbC7j1J2JINV4J86Rv9/RCpRVVEbux9G+PtFdCqcaqF6qZ4QOAPCNDvC75zmsc4OF2x8ZrqaRXLyNSnJv6T2FbfiKH4/ivB1X6CqOJDlET4WFzZyi79VlbkRx7w5ArP72l7iiXDMm5gyJVpD68Xtu96DOOfr5QtOV9LqBlylRw6ShANNPm+aNUmENpK/NMLP8+lp+GKxo0DLaac9eCe0dduJltz5BuK/bMEVdZbpySJbwGGUU1kqQA87+A==
+Received: from ary.qy ([IPv6:2001:470:1f07:1126::78:696d:6170])
+  by imap.iecc.com ([IPv6:2001:470:1f07:1126::78:696d:6170])
+ with ESMTPS (TLS1.3 ECDHE-RSA CHACHA20-POLY1305 AEAD) via TCP6; 25 Sep 2023 01:27:38 -0000
+Received: by ary.qy (Postfix, from userid 501)
+	id 98C8C233963C; Sun, 24 Sep 2023 21:27:38 -0400 (EDT)
+Date: 24 Sep 2023 21:27:38 -0400
+Message-Id: <20230925012738.98C8C233963C@ary.qy>
+From: "John R Levine" <johnl@examp1e.com>
+To: blurch@ietf.org
+Cc: fred@examp1e.com
+Subject: DMARC rewrite test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+
+Test message to test rewrite list
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly
+
+

--- a/postconfirm/testmsg4
+++ b/postconfirm/testmsg4
@@ -1,0 +1,24 @@
+Received: (qmail 10327 invoked from network); 25 Sep 2023 01:22:36 -0000
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=iecc.com; h=date:message-id:from:to:subject:mime-version:content-type; s=2854.6510e0dc.k2309; bh=V0Ayd7IWfoGlAUQ/ASx+ggp9o0Q4YtUHulf4aHcujTs=; b=vNc43XB6UEP+TfQUQESozBHVMu7GbpybKaJ8n3JmrAy4pIUGUmDYv5R3KfLHITF4g/XNHlLb2m+9GNka1SAaGohdmzjlq5/R48eOS/w/Vr6ltc1wU9O0PgYk9uk+JznN43dcNlvR6HExIwD5a7fRGYMALBJ7MswzLXeNXyTittvm40Hw++xkr46zg/HBd8gQJH+LREFRdBr9b17+P3Xq3ixoT3nnHdaKnNP+TozYURJ9oUIOqLFydsr+YCbDeyiKrssi2dUGKZOd/PtmeLVjIIUX6e6XWLyoauBdSyR8wIv7MDYmYrd56hUv/aAeeWN6avOX+BoijKu0dfqwAkjIIQ==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=examp1e.com; h=date:message-id:from:to:subject:mime-version:content-type; s=2854.6510e0dc.k2309; bh=V0Ayd7IWfoGlAUQ/ASx+ggp9o0Q4YtUHulf4aHcujTs=; b=oXK4XaWSezRnm6AFliQkV+yrqoyw0XXhlmP1djg/0ITaoMruieTAgkPuug4Ix20JngaMu/zKYlGqzpRoDBR8bFFLH69EdhKv3VD44+hEDuiCjuEsSBy1Mq03ADA2Tvb6i+AscITx6yg3/p234qL++OC5GbIDQyFSC0kIj7OMt8FTJ42m7GtpLKpNN3orkMBu1wKbnnNsC/n55yCuMj4cM+bJpZqkADa2m10o86VjMf4XaZ8vRcdH7YB7Y2JZVdo4MUe2RnS82NJuM+bowrGP1AzVQAVmLP2y7kQ8hNaW/auctiKlAbyas2c71Z1ZfZ9aZmeC03p1dZ0zOlOdg7+2Uw==
+Received: from ary.qy ([IPv6:2001:470:1f07:1126::78:696d:6170])
+  by imap.iecc.com ([IPv6:2001:470:1f07:1126::78:696d:6170])
+ with ESMTPS (TLS1.3 ECDHE-RSA CHACHA20-POLY1305 AEAD) via TCP6; 25 Sep 2023 01:22:36 -0000
+Received: by ary.qy (Postfix, from userid 501)
+	id B895B2334E78; Sun, 24 Sep 2023 21:22:35 -0400 (EDT)
+Date: 24 Sep 2023 21:22:35 -0400
+Message-Id: <20230925012235.B895B2334E78@ary.qy>
+From: "John R Levine" <johnl@examp1e.com>
+To: ietf@ietf.org
+Subject: List with archive test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+List-ID: <ietf.ietf.org>
+
+Test message to list with archive
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly
+
+

--- a/postconfirm/testmsg5
+++ b/postconfirm/testmsg5
@@ -1,0 +1,22 @@
+Received: (qmail 27451 invoked from network); 25 Sep 2023 03:45:02 -0000
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=iecc.com; h=date:message-id:from:to:subject:mime-version:content-type:list-id; s=6b31.6511023e.k2309; bh=E2Br4XZTqy0Ae8vXJ3UMYOXIqh9eu4pKBJ6H4gnjXUI=; b=n1VUO9ZPvDafqfHAKMd8SVIZa0+IWy449xzFURzZ2mJ+wWKLKpBbNf+X45tld5rQguD8CIYM3gMsGVrOo0Ilzy6mXY7QFOmH8GmX+Kjwo1hmKHA0vZaHTl8l90CpQgA20N/96CTrZHtF9ljpk9ZffLpJjpGn2QUcONneRH5Oz5wjMRnlKIpg0xZjdzKSHz/1QtpdQneS+2aSWG+Fb3QB6KyqX3OL5VygauKK05vGt9DNM1986Oeh68DWNLCvdY32PGzQ4czqTSVmdbicqP4lGFiTd+5c0Fd+K79qyp8FzkMUIw6S/bYEHH/bFen/WTfuR7imBpnQSuwg0Hv2w88xaw==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; d=examp1e.com; h=date:message-id:from:to:subject:mime-version:content-type:list-id; s=6b31.6511023e.k2309; bh=E2Br4XZTqy0Ae8vXJ3UMYOXIqh9eu4pKBJ6H4gnjXUI=; b=Jl2tbQ/+BnWfqXHdEtHzmdOJP9FhI5AC036MJaKuCPfC5v+S8Z2A3lAjbLCTxGaKFYbRQvqAMx87oSOEWFbZhKivQ11FryumQIjbyLuaTIIws2HGWO8uCmCoRjET7woKpcIfUKKHTzjfiGJfBXtwBd8qj0Q1wKYFnkMz6XYb4kWZN2sjgW5fTr1QJxSFVv8K1vr5eQz9hFcgzimjPNlYohwOEGbFlvtAiaq8ntLDytArVSbYX/1YTLrejEdKSGP8HYj+m3jpzR+lHxHdnZpBlJyVCngPdT2dA5CN3bTp6VbI459SXxdNOgsOequrKQdqZ0zL7ops/v/mTMlFfuAr0A==
+Received: from ary.qy ([IPv6:2001:470:1f07:1126::78:696d:6170])
+  by imap.iecc.com ([IPv6:2001:470:1f07:1126::78:696d:6170])
+ with ESMTPS (TLS1.3 ECDHE-RSA CHACHA20-POLY1305 AEAD) via TCP6; 25 Sep 2023 03:45:02 -0000
+Received: by ary.qy (Postfix, from userid 501)
+	id C03FE23AE952; Sun, 24 Sep 2023 23:41:10 -0400 (EDT)
+Date: 24 Sep 2023 23:41:10 -0400
+Message-Id: <20230925034501.C03FE23AE952@ary.qy>
+From: "John R Levine" <johnl@examp1e.com>
+To: iesg@ietf.org
+Subject: List without archive test 1 2 3
+MIME-Version: 1.0
+Content-Type: text/plain; format=flowed; charset=us-ascii
+List-ID: <iesg.ietf.org>
+
+Test message to list without archive
+
+Regards,
+John Levine, johnl@taugh.com, Taughannock Networks, Trumansburg NY
+Please consider the environment before reading this e-mail. https://jl.ly


### PR DESCRIPTION
Don't rewrap headers unless we do anti-DMARC rewrite, to preserve DKIM
Do anti-DMARC rewrite on role forwards
Change envelope return address on forwarded mail