### PR TITLE
fix: bug hunting

### DIFF
--- a/charts/postconfirm/Chart.yaml
+++ b/charts/postconfirm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postconfirm
 description: A Helm chart for deploying postconfirm in Kubernetes
 type: application
-version: 2.1.2
-appVersion: "2.1.2"
+version: 2.1.3
+appVersion: "2.1.3"

--- a/src/milter/processor.py
+++ b/src/milter/processor.py
@@ -254,7 +254,7 @@ async def handle(session: Session) -> Union[Accept, Reject, Discard]:
 
     (mail_subject, mail_headers) = await extract_headers(session)
 
-    cleaned_subject=mail_subject.replace("\n","")
+    cleaned_subject = mail_subject.replace("\n", "").replace("\t", " ")
 
     is_challenge_response = subject_is_challenge_response(cleaned_subject)
 

--- a/src/milter/processor.py
+++ b/src/milter/processor.py
@@ -2,7 +2,7 @@ import logging
 import random
 import re
 import string
-from email.header import decode_header
+from email.header import decode_header, make_header
 from typing import Optional, Union
 
 import chevron
@@ -156,8 +156,8 @@ async def extract_headers(session: Session) -> tuple[Optional[str], list]:
                 mail_subject = value.lstrip()
                 if mail_subject:
                     try:
-                        fixed_subject = bytes(decode_header(mail_subject)[0][0]).decode(decode_header(mail_subject)[0][1])
-                    except:
+                        fixed_subject = str(make_header(decode_header(mail_subject)))
+                    except (ValueError, UnicodeDecodeError):
                         fixed_subject = mail_subject
 
             mail_headers.append((header.name, value))

--- a/src/sender/handler_db.py
+++ b/src/sender/handler_db.py
@@ -78,10 +78,13 @@ class HandlerDb:
         refs = None
 
         try:
-            refs = json.loads(ref_entry)
-        except json.JSONDecodeError:
+            parsed = json.loads(ref_entry)
+            if isinstance(parsed, list):
+                refs = [str(r) for r in parsed]
+            else:
+                refs = [ref_entry]
+        except (json.JSONDecodeError, TypeError):
             if ref_entry:
-                # This must be a bare string, so make it a list.
                 refs = [ref_entry]
 
         return refs

--- a/src/sender/handler_db.py
+++ b/src/sender/handler_db.py
@@ -127,7 +127,7 @@ class HandlerDb:
         """
         with get_db_pool(self.app_config["db"], "db").connection() as connection:
             with connection.cursor() as cursor:
-                parsed_ref = ref[0] if ref else None
+                parsed_ref = json.dumps(ref) if ref else None
 
                 try:
                     cursor.execute(

--- a/src/sender/handler_db_static.py
+++ b/src/sender/handler_db_static.py
@@ -44,16 +44,21 @@ class HandlerDbStatic:
             result = cursor.fetchone()
 
             if result:
-                ref = result[1]
-                if ref:
+                raw_ref = result[1]
+                refs = None
+                if raw_ref:
                     try:
-                        ref = json.loads(ref)
-                    except json.JSONDecodeError:
-                        pass
+                        parsed = json.loads(raw_ref)
+                        if isinstance(parsed, list):
+                            refs = [str(r) for r in parsed]
+                        else:
+                            refs = [raw_ref]
+                    except (json.JSONDecodeError, TypeError):
+                        refs = [raw_ref]
 
                 return (
                     result[0],
-                    ref
+                    refs
                 )
 
         return ('unknown', None)

--- a/tests/test_extract_refs.py
+++ b/tests/test_extract_refs.py
@@ -1,0 +1,55 @@
+import pytest
+
+from src.sender.handler_db import HandlerDb
+
+
+@pytest.fixture
+def handler():
+    return HandlerDb(app_config={"db": {}})
+
+
+class TestExtractRefs:
+    """
+    Tests for HandlerDb._extract_refs().
+
+    The same logic is inlined in HandlerDbStatic.get_action_for_sender(),
+    so these cases cover both code paths.
+    """
+
+    def test_json_list(self, handler):
+        assert handler._extract_refs('["ref1", "ref2"]') == ["ref1", "ref2"]
+
+    def test_json_list_single(self, handler):
+        assert handler._extract_refs('["only-one"]') == ["only-one"]
+
+    def test_numeric_float_string(self, handler):
+        result = handler._extract_refs("20260312224528.645")
+        assert result == ["20260312224528.645"]
+        assert isinstance(result[0], str)
+
+    def test_numeric_integer_string(self, handler):
+        result = handler._extract_refs("12345")
+        assert result == ["12345"]
+        assert isinstance(result[0], str)
+
+    def test_bare_string(self, handler):
+        assert handler._extract_refs("some-ref-id") == ["some-ref-id"]
+
+    def test_json_string_value(self, handler):
+        assert handler._extract_refs('"a-quoted-string"') == ['"a-quoted-string"']
+
+    def test_none(self, handler):
+        assert handler._extract_refs(None) is None
+
+    def test_empty_string(self, handler):
+        assert handler._extract_refs("") is None
+
+    def test_json_list_with_numeric_elements(self, handler):
+        result = handler._extract_refs('[1, 2.5, "abc"]')
+        assert result == ["1", "2.5", "abc"]
+
+    def test_json_object(self, handler):
+        assert handler._extract_refs('{"key": "val"}') == ['{"key": "val"}']
+
+    def test_json_boolean(self, handler):
+        assert handler._extract_refs("true") == ["true"]


### PR DESCRIPTION
Harden ref storage round-trip and fix subject decoding edge cases.

- `_extract_refs()`: guard against `json.loads()` returning non-list types (e.g. numeric Message-IDs parsed as floats); coerce all elements to str; catch `TypeError` alongside `JSONDecodeError`
- `set_action_for_sender()`: store refs as `json.dumps(ref)` instead of `ref[0]`, preserving the full list
- `handler_db_static`: same ref-parsing fix, inlined
- Subject decoding: replace broken use of `bytes(...)` with `str(make_header(decode_header(...)))`; narrow bare except to (`ValueError`, `UnicodeDecodeError`)
- Tab stripping: strip `\t` from folded subjects alongside `\n`
- Add 11 unit tests covering `_extract_refs()` edge cases